### PR TITLE
Rename extension from 'wix-mcp' to 'wix'

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "wix-mcp",
+  "name": "wix",
   "version": "1.0.0",
   "mcpServers": {
     "wix-mcp": {


### PR DESCRIPTION
Gemini CLI team member here 👋 

Gemini CLI extensions are envisioned to be more than just MCP servers, their naming should reflect this.

Remove `-mcp` from the name of the Wix extension to not confuse users 😄 