### PR TITLE
Add description to gemini-extension.json

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,7 @@
 {
   "name": "wix",
   "version": "1.0.0",
+  "description": "Enable Gemini CLI to search the Wix documentation, write code for the Wix platform, and make API calls on Wix sites.",
   "mcpServers": {
     "wix-mcp": {
       "httpUrl": "https://mcp.wix.com/mcp",


### PR DESCRIPTION
The `description` field in `gemini-extension.json` is what gets populated into the description field for a Gemini CLI extension on the marketplace site [geminicli.com/extensions/browse](geminicli.com/extensions/browse).

Improving the description so folks can better understand Wix extension.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/37d09257-3611-4421-82bd-b44db1502abc" />
